### PR TITLE
check annotation category not cat collection

### DIFF
--- a/cocojson/tools/merge.py
+++ b/cocojson/tools/merge.py
@@ -84,7 +84,7 @@ def merge(jsons, img_roots, output_dir, cids=None, outname="merged"):
             merged_dict["images"].append(img)
 
         for annot in cocodict["annotations"]:
-            if cids is not None and cat["id"] not in cids_to_merge:
+            if cids is not None and annot["category_id"] not in cids_to_merge:
                 continue
             annot["id"] = current_annot_id
             current_annot_id += 1


### PR DESCRIPTION
When doing a merge the cid the wrong id was being checked to determine if it should be merged.  

To recreate:
Create json file with the 
   "categories": [
        {
            "id": 1,
            "name": "cat-1",
            "supercategory": ""
        },
        {
            "id": 2,
            "name": "cat-2",
            "supercategory": ""
        },
        {
            "id": 3,
            "name": "cat-3",
            "supercategory": ""
        }
    ]
Create a second with:
   "categories": [
        {
            "id": 1,
            "name": "cat-1",
            "supercategory": ""
        },
        {
            "id": 2,
            "name": "cat-6",
            "supercategory": ""
        },
        {
            "id": 3,
            "name": "cat-3",
            "supercategory": ""
        }
    ]

Then merget the two with -c 1 2 3 from the first and -c 1 3 from the second. 